### PR TITLE
Feature/setting values

### DIFF
--- a/classes/kohana/orm.php
+++ b/classes/kohana/orm.php
@@ -86,7 +86,6 @@ class Kohana_ORM {
 	protected $_object_plural;
 	protected $_table_name;
 	protected $_table_columns;
-	protected $_ignored_columns = array();
 
 	// Auto-update columns for creation and updates
 	protected $_updated_column = NULL;
@@ -187,12 +186,6 @@ class Kohana_ORM {
 		{
 			// Default sorting
 			$this->_sorting = array($this->_primary_key => 'ASC');
-		}
-
-		if ( ! empty($this->_ignored_columns))
-		{
-			// Optimize for performance
-			$this->_ignored_columns = array_combine($this->_ignored_columns, $this->_ignored_columns);
 		}
 
 		foreach ($this->_belongs_to as $alias => $details)
@@ -512,12 +505,7 @@ class Kohana_ORM {
 	 */
 	public function set($column, $value)
 	{
-		if (array_key_exists($column, $this->_ignored_columns))
-		{
-			// No processing for ignored columns, just store it
-			$this->_object[$column] = $value;
-		}
-		elseif (array_key_exists($column, $this->_object))
+		if (array_key_exists($column, $this->_object))
 		{
 			$this->_object[$column] = $value;
 


### PR DESCRIPTION
This is how I would like to set values, the $expected array is the recommended way to define which values the controller is trying to set. This avoids future problems when you add an extra column to a table that you might not want to set from the specific controller action. It removes the risk of the user altering $_POST values to set other columns in the table, and especially useful is the fact that it shows you what is being set with a glance of the controller method. If you don't pass the $expected array, ORM will take all the columns in the model and remove the primary key by default, this also makes you specifically set the primary key if desired but never set it by mistake.

The other change is the fact that filters are run in set(), me and Isaiah (and a few others) feel that Validate should not be altering values. There is no reason for validation to alter the data it is validating. The most logical approach to filters is to make them apply on the way into the model. I think data in the model should always be filtered. If you need to validate an unfiltered value, that is the controller's job to do before validating the model (this will be made easier in my next pull request, when I rewrite in-model validation).
