### PR TITLE
Bugfix/3242 orm sleep db

### DIFF
--- a/classes/kohana/orm.php
+++ b/classes/kohana/orm.php
@@ -358,6 +358,9 @@ class Kohana_ORM {
 	 */
 	public function __wakeup()
 	{
+		// Force the database object out of the serialized object (PHP bug with __sleep())
+		$this->_db = NULL;
+
 		// Initialize model
 		$this->_initialize();
 

--- a/classes/kohana/orm.php
+++ b/classes/kohana/orm.php
@@ -105,6 +105,7 @@ class Kohana_ORM {
 
 	// Database configuration
 	protected $_db         = NULL;
+	protected $_db_group   = NULL;
 	protected $_db_applied = array();
 	protected $_db_pending = array();
 	protected $_db_reset   = TRUE;
@@ -168,7 +169,7 @@ class Kohana_ORM {
 		if ( ! is_object($this->_db))
 		{
 			// Get database instance
-			$this->_db = Database::instance($this->_db);
+			$this->_db = Database::instance($this->_db_group);
 		}
 
 		if (empty($this->_table_name))


### PR DESCRIPTION
I had to create a _db_group property to define the config group the orm model would be using because on __wakeup I need to clear _db. This is one of the reasons it is always a horrible idea to recycle properties for more than one purpose. The _db property should never have been used for both the name of the config group, and the database object. This is an API change, however, because now to specify a different database to use for this model, you need to set _db_group = 'other-db'

On to the reason for this bugfix, when you have a fatal error in PHP sometimes __sleep() is ignored and the entire object is serialized, putting the database object into the session. This database object has the username and password unset for security reasons so when it gets woken up (usually by auth) it will try to connect with no username and password and fail. This patch forces the creation of a new database object by making sure it's not there after __wakeup().

This was a pretty difficult bug to track down =( stupid PHP!

btw here is the php bug http://bugs.php.net/bug.php?id=52604
