### PR TITLE
3.0/master

### DIFF
--- a/classes/kohana/orm.php
+++ b/classes/kohana/orm.php
@@ -1331,7 +1331,7 @@ class Kohana_ORM {
 	 */
 	protected function empty_pk()
 	{
-		return (empty($this->_object[$this->_primary_key]) AND $this->_object[$this->_primary_key] !== '0');
+		return (empty($this->_object[$this->_primary_key]) OR $this->_object[$this->_primary_key] === '0');
 	}
 
 	/**


### PR DESCRIPTION
empty_pk() now checks to see if the PK is empty OR the PK === '0'. The old logic of empty PK AND PK !== '0' will always return FALSE due to $orm->check() turning $orm->_object['id'] into a string from an int.
