### PR TITLE
Added set_values method

### DIFF
--- a/classes/kohana/orm.php
+++ b/classes/kohana/orm.php
@@ -1370,6 +1370,25 @@ class Kohana_ORM extends Model implements serializable {
 	{
 		return $this->loaded() ? $this->update($validation) : $this->create($validation);
 	}
+	
+	/**
+	 * Set records fields automatically from array
+	 *
+	 * @chainable	 
+	 * @param   array    Fields and data (Ex. array('id' = 1))
+	 * @return  ORM
+	 */
+  public function set_values(array $values)
+  {
+        
+    foreach ($values as $k => $value)
+    {
+      if (array_key_exists($k, $this->_table_columns))
+        $this->{$k} = $value;
+    }
+           
+    return $this;        
+  }        
 
 	/**
 	 * Deletes a single record or multiple records, ignoring relationships.

--- a/classes/kohana/orm.php
+++ b/classes/kohana/orm.php
@@ -1552,23 +1552,6 @@ class Kohana_ORM extends Model implements serializable {
 	}
 
 	/**
-	 * Proxy method to Database field_data.
-	 *
-	 * @chainable
-	 * @param  string $sql SQL query to clear
-	 * @return ORM
-	 */
-	public function clear_cache($sql = NULL)
-	{
-		// Proxy to database
-		$this->_db->clear_cache($sql);
-
-		ORM::$_column_cache = array();
-
-		return $this;
-	}
-
-	/**
 	 * Returns an ORM model for the given one-one related alias
 	 *
 	 * @param  string $alias Alias name


### PR DESCRIPTION
I have add an automatic method for set values to a record from array.

This method is very useful when you want populate a record from a array or form.

Example:

``` php
$_POST['id'] = 33;
$_POST['name'] = 'User 33';
$_POST['phone'] = '880 433 434';

$record = ORM::factory('users', $_POST['id'])->set_values($_POST)->save();
```
