### PR TITLE
#4466 - Reconsider ORM::values() behavior and documentation

### DIFF
--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -699,17 +699,8 @@ class Kohana_ORM extends Model implements serializable {
 	 * @param  array $expected Array of keys to take from $values
 	 * @return ORM
 	 */
-	public function values(array $values, array $expected = NULL)
+	public function values(array $values, array $expected)
 	{
-		// Default to expecting everything except the primary key
-		if ($expected === NULL)
-		{
-			$expected = array_keys($this->_table_columns);
-
-			// Don't set the primary key by default
-			unset($values[$this->_primary_key]);
-		}
-
 		foreach ($expected as $key => $column)
 		{
 			if (is_string($key))

--- a/guide/orm/examples/validation.md
+++ b/guide/orm/examples/validation.md
@@ -80,20 +80,21 @@ Please forgive my slightly ugly form. I am trying not to use any modules or unre
 	public function action_create()
 	{
 		$view = View::factory('members/create')
-			->set('values', $_POST)
+			->set('values', $this->request->post())
 			->bind('errors', $errors);
 
-		if ($_POST)
+		if ($this->request->method() === Request::POST)
 		{
 			$member = ORM::factory('member')
 				// The ORM::values() method is a shortcut to assign many values at once
-				->values($_POST, array('username', 'password'));
+				->values($this->request->post(), array('username', 'password'));
 
 			$external_values = array(
 				// The unhashed password is needed for comparing to the password_confirm field
-				'password' => Arr::get($_POST, 'password'),
+				'password' => $this->request->post('password'),
 			// Add all external values
-			) + Arr::get($_POST, '_external', array());
+			) + Arr::get($this->request->post(), '_external', array());
+			
 			$extra = Validation::factory($external_values)
 				->rule('password_confirm', 'matches', array(':validation', ':field', 'password'));
 


### PR DESCRIPTION
http://dev.kohanaframework.org/issues/4466

Though I didn't feel "authorized" to propose such an API change, @Zeelot agreed this should always be forced.

Please notice that ORM::_build_select() is still broken (using table name instead of object name).
