### PR TITLE
Fixes for #4503, #4504, #4018, #3889, #3714

### DIFF
--- a/classes/Kohana/Auth/ORM.php
+++ b/classes/Kohana/Auth/ORM.php
@@ -151,7 +151,7 @@ class Kohana_Auth_ORM extends Auth {
 		if ($token = Cookie::get('authautologin'))
 		{
 			// Load the token and user
-			$token = ORM::factory('user_token', array('token' => $token));
+			$token = ORM::factory('User_Token', array('token' => $token));
 
 			if ($token->loaded() AND $token->user->loaded())
 			{
@@ -217,12 +217,12 @@ class Kohana_Auth_ORM extends Auth {
 			Cookie::delete('authautologin');
 
 			// Clear the autologin token from the database
-			$token = ORM::factory('user_token', array('token' => $token));
+			$token = ORM::factory('User_Token', array('token' => $token));
 
 			if ($token->loaded() AND $logout_all)
 			{
 				// Delete all user tokens. This isn't the most elegant solution but does the job
-				$tokens = ORM::factory('user_token')->where('user_id','=',$token->user_id)->find_all();
+				$tokens = ORM::factory('User_Token')->where('user_id','=',$token->user_id)->find_all();
 				
 				foreach ($tokens as $_token)
 				{

--- a/classes/Kohana/Auth/ORM.php
+++ b/classes/Kohana/Auth/ORM.php
@@ -180,20 +180,19 @@ class Kohana_Auth_ORM extends Auth {
 
 	/**
 	 * Gets the currently logged in user from the session (with auto_login check).
-	 * Returns $default if no user is currently logged in.
+	 * Returns FALSE if no user is currently logged in.
 	 *
-	 * @param   mixed    $default to return in case user isn't logged in
+	 * @param   mixed    $default
 	 * @return  mixed
 	 */
 	public function get_user($default = NULL)
 	{
 		$user = parent::get_user($default);
 
-		if ($user === $default)
+		if ( ! $user)
 		{
 			// check for "remembered" login
-			if (($user = $this->auto_login()) === FALSE)
-				return $default;
+			$user = $this->auto_login();
 		}
 
 		return $user;

--- a/classes/Kohana/Auth/ORM.php
+++ b/classes/Kohana/Auth/ORM.php
@@ -221,7 +221,13 @@ class Kohana_Auth_ORM extends Auth {
 
 			if ($token->loaded() AND $logout_all)
 			{
-				ORM::factory('user_token')->where('user_id', '=', $token->user_id)->delete_all();
+				// Delete all user tokens. This isn't the most elegant solution but does the job
+				$tokens = ORM::factory('user_token')->where('user_id','=',$token->user_id)->find_all();
+				
+				foreach ($tokens as $_token)
+				{
+					$_token->delete();
+				}
 			}
 			elseif ($token->loaded())
 			{

--- a/classes/Kohana/Auth/ORM.php
+++ b/classes/Kohana/Auth/ORM.php
@@ -180,19 +180,20 @@ class Kohana_Auth_ORM extends Auth {
 
 	/**
 	 * Gets the currently logged in user from the session (with auto_login check).
-	 * Returns FALSE if no user is currently logged in.
+	 * Returns $default if no user is currently logged in.
 	 *
-	 * @param   mixed    $default
+	 * @param   mixed    $default to return in case user isn't logged in
 	 * @return  mixed
 	 */
 	public function get_user($default = NULL)
 	{
 		$user = parent::get_user($default);
 
-		if ( ! $user)
+		if ($user === $default)
 		{
 			// check for "remembered" login
-			$user = $this->auto_login();
+			if (($user = $this->auto_login()) === FALSE)
+				return $default;
 		}
 
 		return $user;

--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -28,7 +28,10 @@ class Kohana_ORM extends Model implements serializable {
 	protected static $_init_cache = array();
 
 	/**
-	 * Creates and returns a new model.
+	 * Creates and returns a new model. 
+	 * Model name must be passed with its' original casing, e.g.
+	 * 
+	 *    $model = ORM::factory('User_Token');
 	 *
 	 * @chainable
 	 * @param   string  $model  Model name
@@ -38,7 +41,7 @@ class Kohana_ORM extends Model implements serializable {
 	public static function factory($model, $id = NULL)
 	{
 		// Set class name
-		$model = 'Model_'.ucfirst($model);
+		$model = 'Model_'.$model;
 
 		return new $model($id);
 	}
@@ -331,7 +334,11 @@ class Kohana_ORM extends Model implements serializable {
 
 			foreach ($this->_belongs_to as $alias => $details)
 			{
-				$defaults['model'] = $alias;
+				if ( ! isset($details['model']))
+				{
+					$defaults['model'] = str_replace(' ', '_', ucwords(str_replace('_', ' ', $alias)));
+				}
+				
 				$defaults['foreign_key'] = $alias.$this->_foreign_key_suffix;
 
 				$init['_belongs_to'][$alias] = array_merge($defaults, $details);
@@ -339,7 +346,11 @@ class Kohana_ORM extends Model implements serializable {
 
 			foreach ($this->_has_one as $alias => $details)
 			{
-				$defaults['model'] = $alias;
+				if ( ! isset($details['model']))
+				{
+					$defaults['model'] = str_replace(' ', '_', ucwords(str_replace('_', ' ', $alias)));
+				}
+				
 				$defaults['foreign_key'] = $this->_object_name.$this->_foreign_key_suffix;
 
 				$init['_has_one'][$alias] = array_merge($defaults, $details);
@@ -349,7 +360,7 @@ class Kohana_ORM extends Model implements serializable {
 			{
 				if ( ! isset($details['model']))
 				{
-					$defaults['model'] = Inflector::singular($alias);
+					$defaults['model'] = str_replace(' ', '_', ucwords(str_replace('_', ' ', Inflector::singular($alias))));
 				}
 				
 				$defaults['foreign_key'] = $this->_object_name.$this->_foreign_key_suffix;

--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -577,11 +577,24 @@ class Kohana_ORM extends Model implements serializable {
 
 	/**
 	 * Handles retrieval of all model values, relationships, and metadata.
+	 * [!!] This should not be overridden.
 	 *
 	 * @param   string $column Column name
 	 * @return  mixed
 	 */
 	public function __get($column)
+	{
+		return $this->get($column);
+	}
+	
+	/**
+	 * Handles getting of column
+	 * Override this method to add custom get behavior
+	 *
+	 * @param   string $column Column name
+	 * @return mixed
+	 */
+	public function get($column)
 	{
 		if (array_key_exists($column, $this->_object))
 		{
@@ -660,7 +673,8 @@ class Kohana_ORM extends Model implements serializable {
 	}
 
 	/**
-	 * Base set method - this should not be overridden.
+	 * Base set method.
+	 * [!!] This should not be overridden.
 	 *
 	 * @param  string $column  Column name
 	 * @param  mixed  $value   Column value
@@ -668,20 +682,12 @@ class Kohana_ORM extends Model implements serializable {
 	 */
 	public function __set($column, $value)
 	{
-		if ( ! isset($this->_object_name))
-		{
-			// Object not yet constructed, so we're loading data from a database call cast
-			$this->_cast_data[$column] = $value;
-		}
-		else
-		{
-			// Set the model's column to given value
-			$this->set($column, $value);
-		}
+		$this->set($column, $value);
 	}
 
 	/**
-	 * Handles setting of column
+	 * Handles setting of columns
+	 * Override this method to add custom set behavior
 	 *
 	 * @param  string $column Column name
 	 * @param  mixed  $value  Column value
@@ -689,6 +695,14 @@ class Kohana_ORM extends Model implements serializable {
 	 */
 	public function set($column, $value)
 	{
+		if ( ! isset($this->_object_name))
+		{
+			// Object not yet constructed, so we're loading data from a database call cast
+			$this->_cast_data[$column] = $value;
+			
+			return $this;
+		}
+		
 		if (in_array($column, $this->_serialize_columns))
 		{
 			$value = $this->_serialize_value($value);

--- a/classes/Model/Auth/Role.php
+++ b/classes/Model/Auth/Role.php
@@ -10,7 +10,9 @@
 class Model_Auth_Role extends ORM {
 
 	// Relationships
-	protected $_has_many = array('users' => array('through' => 'roles_users'));
+	protected $_has_many = array(
+		'users' => array('model' => 'User','through' => 'roles_users'),
+	);
 
 	public function rules()
 	{

--- a/classes/Model/Auth/User.php
+++ b/classes/Model/Auth/User.php
@@ -15,8 +15,8 @@ class Model_Auth_User extends ORM {
 	 * @var array Relationhips
 	 */
 	protected $_has_many = array(
-		'user_tokens' => array('model' => 'user_token'),
-		'roles'       => array('model' => 'role', 'through' => 'roles_users'),
+		'user_tokens' => array('model' => 'User_Token'),
+		'roles'       => array('model' => 'Role', 'through' => 'roles_users'),
 	);
 
 	/**
@@ -147,7 +147,7 @@ class Model_Auth_User extends ORM {
 	 *
 	 * Example usage:
 	 * ~~~
-	 * $user = ORM::factory('user')->create_user($_POST, array(
+	 * $user = ORM::factory('User')->create_user($_POST, array(
 	 *	'username',
 	 *	'password',
 	 *	'email',
@@ -174,7 +174,7 @@ class Model_Auth_User extends ORM {
 	 *
 	 * Example usage:
 	 * ~~~
-	 * $user = ORM::factory('user')
+	 * $user = ORM::factory('User')
 	 *	->where('username', '=', 'kiall')
 	 *	->find()
 	 *	->update_user($_POST, array(

--- a/classes/Model/Auth/User/Token.php
+++ b/classes/Model/Auth/User/Token.php
@@ -11,6 +11,11 @@ class Model_Auth_User_Token extends ORM {
 
 	// Relationships
 	protected $_belongs_to = array('user' => array());
+	
+	protected $_created_column = array(
+		'column' => 'created',
+		'format' => TRUE,
+	);
 
 	/**
 	 * Handles garbage collection and deleting of expired objects.

--- a/classes/Model/Auth/User/Token.php
+++ b/classes/Model/Auth/User/Token.php
@@ -10,7 +10,9 @@
 class Model_Auth_User_Token extends ORM {
 
 	// Relationships
-	protected $_belongs_to = array('user' => array());
+	protected $_belongs_to = array(
+		'user' => array('model' => 'User'),
+	);
 	
 	protected $_created_column = array(
 		'column' => 'created',
@@ -67,7 +69,7 @@ class Model_Auth_User_Token extends ORM {
 		{
 			$token = sha1(uniqid(Text::random('alnum', 32), TRUE));
 		}
-		while(ORM::factory('user_token', array('token' => $token))->loaded());
+		while(ORM::factory('User_Token', array('token' => $token))->loaded());
 
 		return $token;
 	}

--- a/guide/orm/examples/simple.md
+++ b/guide/orm/examples/simple.md
@@ -67,7 +67,7 @@ This is a simple example of a single ORM model, that has no relationships, but u
 			 */
 			
 			// Create an instance of a model
-			$members = ORM::factory('member');
+			$members = ORM::factory('Member');
 			
 			// Get all members with the first name "Peter" find_all()
 			// means we get all records matching the query.
@@ -81,7 +81,7 @@ This is a simple example of a single ORM model, that has no relationships, but u
 			 */
 			
 			// Create an instance of a model
-			$member = ORM::factory('member');
+			$member = ORM::factory('Member');
 			
 			// Get a member with the user name "bongo" find() means
 			// we only want the first record matching the query.
@@ -92,7 +92,7 @@ This is a simple example of a single ORM model, that has no relationships, but u
 			 */
 			
 			// Create an instance of a model
-			$member = ORM::factory('member');
+			$member = ORM::factory('Member');
 			
 			// Do an INSERT query
 			$member->username = 'bongo';
@@ -106,7 +106,7 @@ This is a simple example of a single ORM model, that has no relationships, but u
 			
 			// Create an instance of a model where the
 			// table field "id" is "1"
-			$member = ORM::factory('member', 1);
+			$member = ORM::factory('Member', 1);
 			
 			// Do an UPDATE query
 			$member->username = 'bongo';

--- a/guide/orm/examples/validation.md
+++ b/guide/orm/examples/validation.md
@@ -44,7 +44,7 @@ This example will create user accounts and demonstrate how to handle model and c
 		public function username_available($username)
 		{
 			// There are simpler ways to do this, but I will use ORM for the sake of the example
-			return ORM::factory('member', array('username' => $username))->loaded();
+			return ORM::factory('Member', array('username' => $username))->loaded();
 		}
 
 		public function hash_password($password)
@@ -85,7 +85,7 @@ Please forgive my slightly ugly form. I am trying not to use any modules or unre
 
 		if ($_POST)
 		{
-			$member = ORM::factory('member')
+			$member = ORM::factory('Member')
 				// The ORM::values() method is a shortcut to assign many values at once
 				->values($_POST, array('username', 'password'));
 

--- a/guide/orm/relationships.md
+++ b/guide/orm/relationships.md
@@ -37,7 +37,7 @@ If you wanted access a post's author by using code like `$post->author` then you
 
 	protected $_belongs_to = array(
 		'author' => array(
-			'model'       => 'user',
+			'model'       => 'User',
 		),
 	);
 
@@ -68,7 +68,7 @@ Let's assume now you want to access the posts using the name `stories` instead, 
 
 	protected $_has_many = array(
 		'stories' => array(
-			'model'       => 'post',
+			'model'       => 'Post',
 			'foreign_key' => 'author_id',
 		),
 	);
@@ -79,7 +79,7 @@ A `has_one` relationship is almost identical to a `has_many` relationship.  In a
 
 	protected $_has_one = array(
 		'story' => array(
-			'model'       => 'post',
+			'model'       => 'Post',
 			'foreign_key' => 'author_id',
 		),
 	);
@@ -92,7 +92,7 @@ To define the `has_many` "through" relationship, the same syntax for standard ha
 
 	protected $_has_many = array(
 		'categories' => array(
-			'model'   => 'category',
+			'model'   => 'Category',
 			'through' => 'categories_posts',
 		),
 	);
@@ -101,7 +101,7 @@ In the Category model:
 
 	protected $_has_many = array(
 		'posts' => array(
-			'model'   => 'post',
+			'model'   => 'Post',
 			'through' => 'categories_posts',
 		),
 	);

--- a/guide/orm/using.md
+++ b/guide/orm/using.md
@@ -4,7 +4,7 @@
 
 To create a new `Model_User` instance, you can do one of two things:
 
-	$user = ORM::factory('user');
+	$user = ORM::factory('User');
 	// Or
 	$user = new Model_User();
 
@@ -12,7 +12,7 @@ To create a new `Model_User` instance, you can do one of two things:
 
 To insert a new record into the database, create a new instance of the model:
 
-	$user = ORM::factory('user');
+	$user = ORM::factory('User');
 
 Then, assign values for each of the properties;
 
@@ -33,11 +33,11 @@ Insert the new record into the database by running [ORM::save]:
 To find an object you can call the [ORM::find] method or pass the id into the ORM constructor:
 
 	// Find user with ID 20
-	$user = ORM::factory('user')
+	$user = ORM::factory('User')
 		->where('id', '=', 20)
 		->find();
 	// Or
-	$user = ORM::factory('user', 20);
+	$user = ORM::factory('User', 20);
 
 ## Check that ORM loaded a record
 
@@ -70,6 +70,6 @@ And if you want to save the changes you just made back to the database, just run
 
 To delete an object, you can call the [ORM::delete] method on a loaded ORM model.
 
-	$user = ORM::factory('user', 20);
+	$user = ORM::factory('User', 20);
 	$user->delete();
 

--- a/guide/orm/validation.md
+++ b/guide/orm/validation.md
@@ -41,7 +41,7 @@ All models automatically validate their own data when `ORM::save()`, `ORM::updat
 	{
 		try
 		{
-			$user = ORM::factory('user');
+			$user = ORM::factory('User');
 			$user->username = 'invalid username';
 			$user->save();
 		}
@@ -61,7 +61,7 @@ In the below example, the error messages will be defined in `application/message
 	{
 		try
 		{
-			$user = ORM::factory('user');
+			$user = ORM::factory('User');
 			$user->username = 'invalid username';
 			$user->save();
 		}
@@ -79,7 +79,7 @@ Certain forms contain information that should not be validated by the model, but
 	{
 		try
 		{
-			$user = ORM::factory('user');
+			$user = ORM::factory('User');
 			$user->username = $_POST['username'];
 			$user->password = $_POST['password'];
 


### PR DESCRIPTION
I updated the docs to reflect the changes too. Another thing to keep in mind is the extremely ugly PSR-0 replace:

`$foo = str_replace(' ', '_', ucwords(str_replace('_', ' ', $bar)));`

which is also used in `Route::matches()`, this should be moved to the Inflector to keep things DRY.

http://dev.kohanaframework.org/issues/4503
http://dev.kohanaframework.org/issues/4504
http://dev.kohanaframework.org/issues/4018
http://dev.kohanaframework.org/issues/3889
http://dev.kohanaframework.org/issues/3714
