### PR TITLE
fixing ORM model name case

### DIFF
--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -41,7 +41,7 @@ class Kohana_ORM extends Model implements serializable {
 	public static function factory($model, $id = NULL)
 	{
 		// Set class name
-		$model = ' ', '_', ucwords(str_replace('_', ' ', $model)));
+		$model = str_replace(' ', '_', ucwords(str_replace('_', ' ', $model)));
 		$model = 'Model_'.$model;
 
 		return new $model($id);

--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -41,7 +41,8 @@ class Kohana_ORM extends Model implements serializable {
 	public static function factory($model, $id = NULL)
 	{
 		// Set class name
-		$model = 'Model_'.ucwords($model);
+		$model = ' ', '_', ucwords(str_replace('_', ' ', $model)));
+		$model = 'Model_'.$model;
 
 		return new $model($id);
 	}

--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -41,7 +41,7 @@ class Kohana_ORM extends Model implements serializable {
 	public static function factory($model, $id = NULL)
 	{
 		// Set class name
-		$model = 'Model_'.$model;
+		$model = 'Model_'.ucwords($model);
 
 		return new $model($id);
 	}


### PR DESCRIPTION
Some webserver (like phpcl*ud) doesn't recognized non-case-sensitive model name
