### PR TITLE
Change _initialize() to set the object name only if none predefined.  Fixes #4733

### DIFF
--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -288,8 +288,11 @@ class Kohana_ORM extends Model implements serializable {
 	 */
 	protected function _initialize()
 	{
-		// Set the object name and plural name
-		$this->_object_name = strtolower(substr(get_class($this), 6));
+		// Set the object name if none predefined
+		if (empty($this->_object_name))
+		{
+			$this->_object_name = strtolower(substr(get_class($this), 6));
+		}
 		
 		// Check if this model has already been initialized
 		if ( ! $init = Arr::get(ORM::$_init_cache, $this->_object_name, FALSE))


### PR DESCRIPTION
This follows the same pattern as object plural and table name, and gives devs the freedom to set their own name.  This is useful, for example, if you want to translate "Model_FooBar" to "foo_bar" instead of "foobar".

Bug report at:
http://dev.kohanaframework.org/issues/4733
