### PR TITLE
Refs #4730, Fixed Auth_ORM::logged_in not working if $role is an ORM object.

### DIFF
--- a/classes/Kohana/Auth/ORM.php
+++ b/classes/Kohana/Auth/ORM.php
@@ -51,6 +51,10 @@ class Kohana_Auth_ORM extends Auth {
 					if ( ! $roles->loaded())
 						return FALSE;
 				}
+				else
+				{
+					$roles = $role;
+				}
 			}
 
 			return $user->has('roles', $roles);


### PR DESCRIPTION
Fixes: http://dev.kohanaframework.org/issues/4730
