### PR TITLE
Make ORM::count_all() use table_name.primary_key instead of just primary_key

### DIFF
--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -1644,7 +1644,7 @@ class Kohana_ORM extends Model implements serializable {
 		$this->_build(Database::SELECT);
 
 		$records = $this->_db_builder->from(array($this->_table_name, $this->_object_name))
-			->select(array(DB::expr('COUNT('.$this->_db->quote_column($this->_primary_key).')'), 'records_found'))
+			->select(array(DB::expr('COUNT('.$this->_db->quote_column($this->_table_name.'.'.$this->_primary_key).')'), 'records_found'))
 			->execute($this->_db)
 			->get('records_found');
 


### PR DESCRIPTION
ORM::factory('Table1')->with('table2')->count_all() would generate invalid query if both table1 and table2 had it's primary key set to the same value. Primary key would be ambiguous in the generated SQL.
