### PR TITLE
->has() method will return true, if many-to-many 'through' table has dup...

### DIFF
--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -1472,7 +1472,7 @@ class Kohana_ORM extends Model implements serializable {
 		}
 		else
 		{
-			return $count === count($far_keys);
+			return $count >= count($far_keys);
 		}
 
 	}


### PR DESCRIPTION
...licate rows.

Previously: if there are two rows in 'through' table, it will return false. This situation could happen if the table has no appropriate unique indexes and ->add was used more than once.
