### PR TITLE
Refs #4497: ORM::values() second param isn't optional anymore

### DIFF
--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -769,7 +769,7 @@ class Kohana_ORM extends Model implements serializable {
 	 * This method should be used for loading in post data, etc.
 	 *
 	 * @param  array $values   Array of column => value pairs
-	 * @param  array $columns  Array of columns to be set, allows setting related model data
+	 * @param  array $columns  Array of columns to be set
 	 * @return ORM
 	 */
 	public function values(array $values, array $columns)

--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -765,25 +765,16 @@ class Kohana_ORM extends Model implements serializable {
 	}
 
 	/**
-	 * Set values from an array with support for one-one relationships.  This method should be used
-	 * for loading in post data, etc.
+	 * Set values from an array with support for one-one relationships.  
+	 * This method should be used for loading in post data, etc.
 	 *
-	 * @param  array $values   Array of column => val
-	 * @param  array $expected Array of keys to take from $values
+	 * @param  array $values   Array of column => value pairs
+	 * @param  array $columns  Array of columns to be set, allows setting related model data
 	 * @return ORM
 	 */
-	public function values(array $values, array $expected = NULL)
+	public function values(array $values, array $columns)
 	{
-		// Default to expecting everything except the primary key
-		if ($expected === NULL)
-		{
-			$expected = array_keys($this->_table_columns);
-
-			// Don't set the primary key by default
-			unset($values[$this->_primary_key]);
-		}
-
-		foreach ($expected as $key => $column)
+		foreach ($columns as $key => $column)
 		{
 			if (is_string($key))
 			{

--- a/guide/orm/using.md
+++ b/guide/orm/using.md
@@ -90,5 +90,5 @@ To set multiple values at once, use [ORM::values]
 		// Handle validation errors ...
 	}
 	
-[!!] Although the second argument is optional, it is *highly recommended* to specify the list of columns you expect to change. Not doing so will leave your code _vulnerable_ in case the attacker adds fields you didn't expect.
+[!!] Second argument is not optional anymore, allowing all fields to change will leave your code _vulnerable_ in case the attacker adds fields you didn't expect.
 


### PR DESCRIPTION
The 3rd PR for the same thing... yep, it happens :)
