### PR TITLE
Alias column names should be surrounded by backticks otherwise it causes...

### DIFF
--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -892,7 +892,7 @@ class Kohana_ORM extends Model implements serializable {
 		foreach (array_keys($target->_object) as $column)
 		{
 			$name = $target_path.'.'.$column;
-			$alias = $target_path.':'.$column;
+			$alias = '`'.$target_path.':'.$column.'`';
 
 			// Add the prefix so that load_result can determine the relationship
 			$this->select(array($name, $alias));


### PR DESCRIPTION
Alias column names should be surrounded by backticks otherwise it causes SQL syntax errors. 
See this thread: http://forum.kohanaframework.org/discussion/comment/63963
