### PR TITLE
Allow ORM::has() to check a single far key

### DIFF
--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -1442,7 +1442,7 @@ class Kohana_ORM extends Model implements serializable {
 	 * 
 	 *
 	 *     // Check if $model has the login role
-	 *     $model->has('roles', ORM::factory('role', array('name' => 'login')));
+	 *     $model->has('roles', ORM::factory('Role', array('name' => 'login')));
 	 *     // Check for the login role if you know the roles.id is 5
 	 *     $model->has('roles', 5);
 	 *     // Check for all of the following roles
@@ -1484,7 +1484,7 @@ class Kohana_ORM extends Model implements serializable {
 	 * only checks that at least one of the relationships is satisfied.
 	 *
 	 *     // Check if $model has the login role
-	 *     $model->has('roles', ORM::factory('role', array('name' => 'login')));
+	 *     $model->has('roles', ORM::factory('Role', array('name' => 'login')));
 	 *     // Check for the login role if you know the roles.id is 5
 	 *     $model->has('roles', 5);
 	 *     // Check for any of the following roles
@@ -1505,7 +1505,7 @@ class Kohana_ORM extends Model implements serializable {
 	 * Returns the number of relationships 
 	 *
 	 *     // Counts the number of times the login role is attached to $model
-	 *     $model->count_relations('roles', ORM::factory('role', array('name' => 'login')));
+	 *     $model->count_relations('roles', ORM::factory('Role', array('name' => 'login')));
 	 *     // Counts the number of times role 5 is attached to $model
 	 *     $model->count_relations('roles', 5);
 	 *     // Counts the number of times any of roles 1, 2, 3, or 4 are attached to

--- a/classes/Kohana/ORM.php
+++ b/classes/Kohana/ORM.php
@@ -1463,6 +1463,16 @@ class Kohana_ORM extends Model implements serializable {
 		}
 		else
 		{
+			if ($far_keys instanceof ORM && ! $far_keys->loaded())
+			{
+				return FALSE;
+			}
+
+			if ( ! Arr::is_array($far_keys))
+			{
+				$far_keys = array($far_keys);
+			}
+
 			return $count === count($far_keys);
 		}
 


### PR DESCRIPTION
```
return $count === count($far_keys);
```

Any ORM model or a single primary key (int) will always fail this comparison.

Added further checks to return FALSE if far_keys is an instance of ORM and not loaded and build an array if $far_keys was not an array.
